### PR TITLE
Add option to hide leading back button

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ There are many customization options:
 | `clearQueryOnClose`         | Whether the current query should be cleared when the `FloatingSearchBar` was closed. <br><br> When not specifed, defaults to `true`.
 | `showDrawerHamburger`       | Whether a hamburger menu should be shown when there is a `Scaffold` with a `Drawer` in the widget tree.
 | `closeOnBackdropTap`        | Whether the `FloatingSearchBar` should be closed when the backdrop was tapped. <br><br> When not specified, defaults to `true`.
-| `showLeadingBack`           | Whether to determine and show the leading back button automatically.<br><br> When not specified, defaults to `true`.
+| `hideLeadingBack`           | Whether to hide the leading back button completely.<br><br> When not specified, defaults to `false`.
 | `progress`                  | The progress of the `LinearProgressIndicator` inside the card. <br><br> When set to a `double` between `0..1`, will show show a determined `LinearProgressIndicator`. <br><br> When set to `true`, the `FloatingSearchBar` will show an indetermined `LinearProgressIndicator`. <br><br> When `null` or `false`, will hide the `LinearProgressIndicator`.
 | `transitionDuration`       |  The duration of the animation between opened and closed state.
 | `transitionCurve`          |  The curve for the animation between opened and closed state.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ There are many customization options:
 | `clearQueryOnClose`         | Whether the current query should be cleared when the `FloatingSearchBar` was closed. <br><br> When not specifed, defaults to `true`.
 | `showDrawerHamburger`       | Whether a hamburger menu should be shown when there is a `Scaffold` with a `Drawer` in the widget tree.
 | `closeOnBackdropTap`        | Whether the `FloatingSearchBar` should be closed when the backdrop was tapped. <br><br> When not specified, defaults to `true`.
+| `showLeadingBack`           | Whether to determine and show the leading back button automatically.<br><br> When not specified, defaults to `true`.
 | `progress`                  | The progress of the `LinearProgressIndicator` inside the card. <br><br> When set to a `double` between `0..1`, will show show a determined `LinearProgressIndicator`. <br><br> When set to `true`, the `FloatingSearchBar` will show an indetermined `LinearProgressIndicator`. <br><br> When `null` or `false`, will hide the `LinearProgressIndicator`.
 | `transitionDuration`       |  The duration of the animation between opened and closed state.
 | `transitionCurve`          |  The curve for the animation between opened and closed state.

--- a/lib/src/floating_search_app_bar.dart
+++ b/lib/src/floating_search_app_bar.dart
@@ -87,7 +87,7 @@ class FloatingSearchAppBar extends ImplicitlyAnimatedWidget {
   final bool hideKeyboardOnDownScroll;
 
   /// {@macro floating_search_bar.showLeadingBack}
-  final bool showLeadingBack;
+  final bool hideLeadingBack;
 
   /// {@macro floating_search_bar.progress}
   final dynamic progress;
@@ -159,7 +159,7 @@ class FloatingSearchAppBar extends ImplicitlyAnimatedWidget {
     this.clearQueryOnClose = true,
     this.showDrawerHamburger = true,
     this.hideKeyboardOnDownScroll = false,
-    this.showLeadingBack = true,
+    this.hideLeadingBack = false,
     this.progress = 0.0,
     this.transitionDuration = const Duration(milliseconds: 500),
     this.transitionCurve = Curves.easeOut,
@@ -238,7 +238,7 @@ class FloatingSearchAppBarState extends ImplicitlyAnimatedWidgetState<
     Widget leading;
     if (showHamburger) {
       leading = FloatingSearchBarAction.hamburgerToBack();
-    } else if (widget.showLeadingBack &&
+    } else if (!widget.hideLeadingBack &&
         (Navigator.canPop(context) || widget.body != null)) {
       leading =
           FloatingSearchBarAction.back(showIfClosed: Navigator.canPop(context));

--- a/lib/src/floating_search_app_bar.dart
+++ b/lib/src/floating_search_app_bar.dart
@@ -86,6 +86,9 @@ class FloatingSearchAppBar extends ImplicitlyAnimatedWidget {
   /// shows it again when the user scrolls to the top.
   final bool hideKeyboardOnDownScroll;
 
+  /// {@macro floating_search_bar.showLeadingBack}
+  final bool showLeadingBack;
+
   /// {@macro floating_search_bar.progress}
   final dynamic progress;
 
@@ -156,6 +159,7 @@ class FloatingSearchAppBar extends ImplicitlyAnimatedWidget {
     this.clearQueryOnClose = true,
     this.showDrawerHamburger = true,
     this.hideKeyboardOnDownScroll = false,
+    this.showLeadingBack = true,
     this.progress = 0.0,
     this.transitionDuration = const Duration(milliseconds: 500),
     this.transitionCurve = Curves.easeOut,
@@ -234,7 +238,8 @@ class FloatingSearchAppBarState extends ImplicitlyAnimatedWidgetState<
     Widget leading;
     if (showHamburger) {
       leading = FloatingSearchBarAction.hamburgerToBack();
-    } else if (Navigator.canPop(context) || widget.body != null) {
+    } else if (widget.showLeadingBack &&
+        (Navigator.canPop(context) || widget.body != null)) {
       leading =
           FloatingSearchBarAction.back(showIfClosed: Navigator.canPop(context));
     }

--- a/lib/src/floating_search_bar.dart
+++ b/lib/src/floating_search_bar.dart
@@ -161,6 +161,11 @@ class FloatingSearchBar extends ImplicitlyAnimatedWidget {
   /// When not specified, defaults to `true`.
   final bool closeOnBackdropTap;
 
+  /// Whether to determine and show the leading back button automatically.
+  ///
+  /// When not specified, defaults to `true`.
+  final bool showLeadingBack;
+
   /// {@template floating_search_bar.progress}
   /// The progress of the [LinearProgressIndicator] inside the bar.
   ///
@@ -358,6 +363,7 @@ class FloatingSearchBar extends ImplicitlyAnimatedWidget {
     this.clearQueryOnClose = true,
     this.showDrawerHamburger = true,
     this.closeOnBackdropTap = true,
+    this.showLeadingBack = true,
     this.progress = false,
     this.transitionDuration = const Duration(milliseconds: 500),
     this.transitionCurve = Curves.ease,
@@ -723,6 +729,7 @@ class FloatingSearchBarState extends ImplicitlyAnimatedWidgetState<
       onSubmitted: widget.onSubmitted,
       progress: widget.progress,
       showDrawerHamburger: widget.showDrawerHamburger,
+      showLeadingBack: widget.showLeadingBack,
       toolbarOptions: widget.toolbarOptions,
       transitionDuration: widget.transitionDuration,
       transitionCurve: widget.transitionCurve,

--- a/lib/src/floating_search_bar.dart
+++ b/lib/src/floating_search_bar.dart
@@ -161,10 +161,10 @@ class FloatingSearchBar extends ImplicitlyAnimatedWidget {
   /// When not specified, defaults to `true`.
   final bool closeOnBackdropTap;
 
-  /// Whether to determine and show the leading back button automatically.
+  /// Whether to hide the leading back button completely.
   ///
-  /// When not specified, defaults to `true`.
-  final bool showLeadingBack;
+  /// When not specified, defaults to `false`.
+  final bool hideLeadingBack;
 
   /// {@template floating_search_bar.progress}
   /// The progress of the [LinearProgressIndicator] inside the bar.
@@ -363,7 +363,7 @@ class FloatingSearchBar extends ImplicitlyAnimatedWidget {
     this.clearQueryOnClose = true,
     this.showDrawerHamburger = true,
     this.closeOnBackdropTap = true,
-    this.showLeadingBack = true,
+    this.hideLeadingBack = false,
     this.progress = false,
     this.transitionDuration = const Duration(milliseconds: 500),
     this.transitionCurve = Curves.ease,
@@ -729,7 +729,7 @@ class FloatingSearchBarState extends ImplicitlyAnimatedWidgetState<
       onSubmitted: widget.onSubmitted,
       progress: widget.progress,
       showDrawerHamburger: widget.showDrawerHamburger,
-      showLeadingBack: widget.showLeadingBack,
+      hideLeadingBack: widget.hideLeadingBack,
       toolbarOptions: widget.toolbarOptions,
       transitionDuration: widget.transitionDuration,
       transitionCurve: widget.transitionCurve,


### PR DESCRIPTION
The current behaviour for the leading back button to show is either through specifying `showHamburger` or it determines automatically based on `Navigator.canPop(context) || widget.body != null`. However, if a dialog is shown after searching through the search bar, the back button will be displayed. But after popping the dialog, the back button remains and there is nothing else to pop.

Adding `hideLeadingBack` option to allow overriding the default/current behaviour and hide the back button.