### PR TITLE
Search bar translation opacity

### DIFF
--- a/lib/src/floating_search_bar.dart
+++ b/lib/src/floating_search_bar.dart
@@ -500,9 +500,7 @@ class FloatingSearchBarState extends ImplicitlyAnimatedWidgetState<
       duration: const Duration(milliseconds: 0),
     );
 
-    _translateOpacityAnimation = Tween(begin: 1.0, end: 0.0)
-      .animate(_translateOpacityController);
-    // _translateOpacityAnimation = CurvedAnimation(parent: _translateOpacityController, curve: Curves.fastLinearToSlowEaseIn);
+    _translateOpacityAnimation = CurvedAnimation(parent: _translateController, curve: Curves.fastOutSlowIn);
 
     transition = widget.transition ?? SlideFadeFloatingSearchBarTransition();
 
@@ -605,9 +603,6 @@ class FloatingSearchBarState extends ImplicitlyAnimatedWidgetState<
         _translateController.value += delta / (height + _resolve(margins).top);
         _lastPixel = pixel;
       }
-
-      if (widget.fadeOffscreen)
-        _translateOpacityController.animateTo(_translateController.value);
     }
 
     return false;
@@ -667,9 +662,9 @@ class FloatingSearchBarState extends ImplicitlyAnimatedWidgetState<
         final borderRadius = transition.lerpBorderRadius();
 
         final container = AnimatedBuilder(
-          animation: _translateOpacityController,
+          animation: _translateController,
           builder: (context, _) => Opacity(
-            opacity: _translateOpacityAnimation.value,
+            opacity: 1 - _translateOpacityAnimation.value,
             child: Semantics(
               hidden: !isVisible,
               focusable: true,

--- a/lib/src/floating_search_bar.dart
+++ b/lib/src/floating_search_bar.dart
@@ -500,9 +500,9 @@ class FloatingSearchBarState extends ImplicitlyAnimatedWidgetState<
       duration: const Duration(milliseconds: 0),
     );
 
-    Tween(begin: 1.0, end: 0.0)
+    _translateOpacityAnimation = Tween(begin: 1.0, end: 0.0)
       .animate(_translateOpacityController);
-    _translateOpacityAnimation = _translateOpacityController.drive(CurveTween(curve: Curves.fastLinearToSlowEaseIn));
+    // _translateOpacityAnimation = CurvedAnimation(parent: _translateOpacityController, curve: Curves.fastLinearToSlowEaseIn);
 
     transition = widget.transition ?? SlideFadeFloatingSearchBarTransition();
 


### PR DESCRIPTION
To enable an appearance more similar to the Gmail app - an animated opacity transition is required.

This pull request provides an additional constructor option
```
FloatingSearchBar({ fadeOffscreen: true|false }) 
```

Before the PR, or with the option **disabled** , this is the transition appearance:
![floating_search_bar_transition_nofade](https://user-images.githubusercontent.com/16373742/103046132-009fc080-45ec-11eb-927d-79729db5137e.gif)

After the PR, with the option  **enabled**, this is the transition appearance:
![floating_search_bar_transition_fade](https://user-images.githubusercontent.com/16373742/103046153-10b7a000-45ec-11eb-897d-39ff1b3314c3.gif)
